### PR TITLE
fix dependency test dockerfile

### DIFF
--- a/tests/Dockerfile_no_lock
+++ b/tests/Dockerfile_no_lock
@@ -1,8 +1,14 @@
 FROM python:3.7-slim-buster
-RUN pip install poetry
-COPY pyproject.toml /
-RUN poetry config virtualenvs.create false \
-&& poetry install --no-interaction --no-ansi
-COPY . /validator
+
 WORKDIR /validator
-ENTRYPOINT pytest /validator/tests -vv
+
+RUN python -m pip install --upgrade pip
+RUN pip install poetry
+
+COPY . /validator
+RUN rm /validator/poetry.lock
+
+RUN poetry config virtualenvs.create false \
+  && poetry install --no-interaction --no-ansi
+
+ENTRYPOINT pytest tests/ -vv


### PR DESCRIPTION
Fixes #47 (deleting `poetry.lock` after copying rather than messing with regex saved a lot of sanity)