### PR TITLE
Fix testing scopes

### DIFF
--- a/data_linter/utils.py
+++ b/data_linter/utils.py
@@ -11,14 +11,12 @@ from dataengineeringutils3.s3 import (
     write_local_file_to_s3,
 )
 
-s3_client = boto3.client("s3")
-
-
 # import logging
 # log = logging.getLogger("root")
 
 
 def download_data(s3_path: str, local_path: str):
+    s3_client = boto3.client("s3")
     dirname = os.path.dirname(local_path)
     Path(dirname).mkdir(parents=True, exist_ok=True)
     with open(local_path, "wb") as f:
@@ -27,6 +25,7 @@ def download_data(s3_path: str, local_path: str):
 
 
 def compress_data(s3_download_path: str, s3_upload_path: str):
+    s3_client = boto3.client("s3")
     with tempfile.TemporaryDirectory() as temp_dir:
         bucket, key = s3_path_to_bucket_key(s3_download_path)
         temp_file = os.path.join(temp_dir, key.split("/")[-1])
@@ -64,6 +63,8 @@ def get_log_path(basepath: str, table: str, ts: str, filenum: int = 0) -> str:
 
 
 def local_file_to_s3(local_path: str, s3_path: str):
+    s3_client = boto3.client("s3")
+
     if (not local_path.endswith(".gz")) and (s3_path.endswith(".gz")):
         new_path = local_path + ".gz"
         with open(local_path, "rb") as f_in, gzip.open(new_path, "wb") as f_out:

--- a/data_linter/validation.py
+++ b/data_linter/validation.py
@@ -3,7 +3,6 @@ import yaml
 import json
 import re
 import logging
-import sys
 
 from datetime import datetime
 

--- a/data_linter/validation.py
+++ b/data_linter/validation.py
@@ -485,6 +485,6 @@ def run_validation(config_path="config.yaml"):
 
         upload_log(body=log_stringio.getvalue(), s3_path=log_path)
 
-        raise type(e)(str(e)).with_traceback(sys.exc_info()[2])
+        raise e.with_traceback(e.__traceback__)
     else:
         upload_log(body=log_stringio.getvalue(), s3_path=log_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ def aws_credentials():
 @pytest.fixture
 def s3(aws_credentials):
     with mock_s3():
-        boto3.setup_default_session()
         yield boto3.resource("s3", region_name="eu-west-1")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from moto import mock_s3
 import pytest
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"
@@ -14,14 +14,14 @@ def aws_credentials():
     os.environ["AWS_SESSION_TOKEN"] = "testing"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def s3(aws_credentials):
     with mock_s3():
         boto3.setup_default_session()
         yield boto3.resource("s3", region_name="eu-west-1")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def s3_client(aws_credentials):
     with mock_s3():
         yield boto3.client("s3", region_name="eu-west-1")

--- a/tests/test_end_to_end_run.py
+++ b/tests/test_end_to_end_run.py
@@ -3,6 +3,7 @@ import yaml
 import gzip
 import tempfile
 
+import pytest
 
 def set_up_s3(mocked_s3, test_folder, config):
     from dataengineeringutils3.s3 import s3_path_to_bucket_key
@@ -40,6 +41,19 @@ def test_end_to_end(s3):
     set_up_s3(s3, test_folder, config)
     run_validation(config_path)
     os.system(f"python data_linter/command_line.py --config-path {config_path}")
+
+
+def test_end_to_end_no_creds_error():
+
+    from data_linter.validation import run_validation
+    from botocore.exceptions import ClientError
+
+    test_folder = "tests/data/end_to_end1/"
+    config_path = os.path.join(test_folder, "config.yaml")
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+    with pytest.raises(ClientError):
+        run_validation(config_path)
 
 
 def test_compression(s3):

--- a/tests/test_end_to_end_run.py
+++ b/tests/test_end_to_end_run.py
@@ -51,8 +51,7 @@ def test_end_to_end_no_creds_error():
 
     test_folder = "tests/data/end_to_end1/"
     config_path = os.path.join(test_folder, "config.yaml")
-    with open(config_path) as f:
-        config = yaml.safe_load(f)
+
     with pytest.raises(ClientError):
         run_validation(config_path)
 

--- a/tests/test_end_to_end_run.py
+++ b/tests/test_end_to_end_run.py
@@ -5,6 +5,7 @@ import tempfile
 
 import pytest
 
+
 def set_up_s3(mocked_s3, test_folder, config):
     from dataengineeringutils3.s3 import s3_path_to_bucket_key
 

--- a/tests/test_moto.py
+++ b/tests/test_moto.py
@@ -4,6 +4,7 @@ import os
 def test_download_fileobj(s3_client):
     # s3 is a fixture defined above that yields a boto3 s3 client.
     from dataengineeringutils3.s3 import s3_path_to_bucket_key
+
     s3_client.create_bucket(Bucket="somebucket")
     s3_download_path = "somebucket/"
     bucket, key = s3_path_to_bucket_key(s3_download_path)


### PR DESCRIPTION
Moving S3 client within the scope of each util function - otherwise moto seems to have issues. Assuming that it's state is saved when shared across multiple functional calls - which if true we don't want anyway.

Also got rid of scope set to function as that is the default.