### PR TITLE
fix typo in get_out_path function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v1.1.2 - 2020-09-23
+
+- Fix typo in get_out_path function
+
 ## v1.1.1 - 2020-09-17
 
 - Added some more print statements (#75)

--- a/data_linter/utils.py
+++ b/data_linter/utils.py
@@ -50,7 +50,7 @@ def get_out_path(
         final_filename += ".gz"
 
     out_path = os.path.join(
-        basepath, table, f"mojap_fileland_timestamp={ts}", final_filename
+        basepath, table, f"mojap_file_land_timestamp={ts}", final_filename
     )
     return out_path
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "data_linter"
-version = "1.1.1"
+version = "1.1.2"
 description = "data linter"
 authors = ["Thomas Hirsch <thomas.hirsch@digital.justice.gov.uk>",
            "George Kelly <george.kelly@digital.justice.gov.uk>",


### PR DESCRIPTION
don't mind the accidentally reused branch name. Also not certain about the version numbering, as it is technically breaking functionality, though I'm not sure how widely it's actually used.