### PR TITLE
splitting out config validation code

### DIFF
--- a/data_linter/validation.py
+++ b/data_linter/validation.py
@@ -66,6 +66,13 @@ def load_and_validate_config(config_path: str = "config.yaml") -> dict:
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)
 
+    config = validate_and_clean_config(config)
+    json_validate(config, config_schema)
+
+    return config
+
+
+def validate_and_clean_config(config: dict) -> dict:
     json_validate(config, config_schema)
 
     for table_name, params in config["tables"].items():

--- a/data_linter/validation.py
+++ b/data_linter/validation.py
@@ -66,10 +66,7 @@ def load_and_validate_config(config_path: str = "config.yaml") -> dict:
     with open(config_path, "r") as f:
         config = yaml.safe_load(f)
 
-    config = validate_and_clean_config(config)
-    json_validate(config, config_schema)
-
-    return config
+    return validate_and_clean_config(config)
 
 
 def validate_and_clean_config(config: dict) -> dict:

--- a/data_linter/validation.py
+++ b/data_linter/validation.py
@@ -72,7 +72,7 @@ def load_and_validate_config(config_path: str = "config.yaml") -> dict:
 
 
 def validate_and_clean_config(config: dict) -> dict:
-    """Validates a config as a dict. And adds default 
+    """Validates a config as a dict. And adds default
     properties to that config.
 
     Args:

--- a/data_linter/validation.py
+++ b/data_linter/validation.py
@@ -4,6 +4,8 @@ import json
 import re
 import logging
 
+from typing import Union
+
 from datetime import datetime
 
 from jsonschema import validate as json_validate
@@ -38,8 +40,8 @@ import pprint
 
 pp = pprint.PrettyPrinter(indent=4)
 
-config = Config(read_timeout=120)
-s3_client = boto3.client("s3", config=config)
+boto3_config = Config(read_timeout=120)
+s3_client = boto3.client("s3", config=boto3_config)
 
 log = logging.getLogger("root")
 
@@ -70,6 +72,15 @@ def load_and_validate_config(config_path: str = "config.yaml") -> dict:
 
 
 def validate_and_clean_config(config: dict) -> dict:
+    """Validates a config as a dict. And adds default 
+    properties to that config.
+
+    Args:
+        config (dict): Config for data linter validation run.
+
+    Returns:
+        dict: The same config but with default params added.
+    """
     json_validate(config, config_schema)
 
     for table_name, params in config["tables"].items():
@@ -478,12 +489,13 @@ def validate_data(config: dict):
         log.info(m6)
 
 
-def run_validation(config_path="config.yaml"):
+def run_validation(config: Union[str, dict] = "config.yaml"):
     """
     Runs end to end validation based on config.
 
     Args:
-        config_path (str, optional): [description]. Defaults to "config.yaml".
+        config (Union[str, dict], optional): Either a string specifying the path to a
+        config yaml. Or a dict of a config in memory. Defaults to "config.yaml".
 
     Raises:
         Error: States where log is written if error is hit in validation and then raises
@@ -495,7 +507,13 @@ def run_validation(config_path="config.yaml"):
 
     log.info("Loading config")
     try:
-        config = load_and_validate_config(config_path)
+        if isinstance(config, str):
+            config = load_and_validate_config(config)
+        elif isinstance(config, dict):
+            config = validate_and_clean_config(config)
+        else:
+            raise TypeError("Input 'config' must be a str or dict.")
+
         log_path = os.path.join(config["log-base-path"], get_validator_name() + ".log")
         log.info("Running validation")
         validate_data(config)


### PR DESCRIPTION
Separating out functionality so users can provide a config in memory rather than a file