### PR TITLE
Added "/" to match file check

### DIFF
--- a/data_linter/validation.py
+++ b/data_linter/validation.py
@@ -171,7 +171,9 @@ def match_files_in_land_to_config(config: dict) -> dict:
             table_params["matched_files"] = [
                 land_file
                 for land_file in land_files
-                if land_file.replace(land_base_path, "").startswith(table_name)
+                if land_file.replace(land_base_path, "").startswith(
+                    table_name + "/"
+                )
             ]
 
         if not table_params["matched_files"] and table_params.get("required"):


### PR DESCRIPTION
If two tables exist where the name of one is a substring of the other (e.g. `table1` and `table1_duplicate`) then linting for the first table will pick up files for the second. This commit adds a "/" to the `startswith` clause that gets the matching files for each table, so that this doesn't happen.