### PR TITLE
Fix reading parquet schema from S3

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,10 @@
-import os
 import io
-import boto3
+import os
+import pathlib
 from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+
+import boto3
 from dataengineeringutils3.s3 import s3_path_to_bucket_key
 
 
@@ -67,6 +70,15 @@ class MockS3FilesystemReadInputStream:
             yield obj_io_bytes
         finally:
             obj_io_bytes.close()
+
+    @staticmethod
+    @contextmanager
+    def open_input_file(s3_file_path_in: str):
+        s3_client = boto3.client("s3")
+        bucket, key = s3_path_to_bucket_key(s3_file_path_in)
+        tmp_file = NamedTemporaryFile(suffix=pathlib.Path(key).suffix)
+        s3_client.download_file(bucket, key, tmp_file.name)
+        yield tmp_file.name
 
 
 def mock_get_file(*args, **kwargs):

--- a/tests/test_parquet_validator.py
+++ b/tests/test_parquet_validator.py
@@ -1,7 +1,49 @@
-import pytest
 import os
-from data_linter.validators.parquet_validator import ParquetValidator
+
+import awswrangler as wr
+import boto3
+import pytest
 from mojap_metadata import Metadata
+from moto import mock_s3
+from pyarrow.parquet import read_schema
+
+import data_linter.validators.parquet_validator as pqv
+from tests.helpers import mock_get_file
+
+bucket = "dummy-bucket"
+
+
+@mock_s3
+@pytest.mark.parametrize(
+    "filepath, mock_s3",
+    [
+        ("tests/data/parquet_validator/table1.parquet", True),
+        ("tests/data/parquet_validator/table1.parquet", False),
+    ],
+)
+def test_parquet_schema_reader(filepath, mock_s3, monkeypatch):
+    if mock_s3:
+
+        s3_client = boto3.client("s3")
+        _ = s3_client.create_bucket(
+            Bucket=bucket,
+            CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+        )
+
+        full_path = f"s3://{bucket}/{filepath}"
+
+        wr.s3.upload(filepath, full_path)
+
+    else:
+        full_path = filepath
+
+    _ = monkeypatch.setattr(pqv, "S3FileSystem", mock_get_file)
+
+    schema = pqv.ParquetValidator._read_schema(full_path)
+
+    expected_schema = read_schema(filepath).remove_metadata()
+
+    assert expected_schema == schema
 
 
 @pytest.mark.parametrize(
@@ -17,6 +59,6 @@ def test_parquet_validator(meta_file, expected_pass):
         os.path.join("tests/data/parquet_validator/meta_data/", meta_file)
     )
     file_path = "tests/data/parquet_validator/table1.parquet"
-    pv = ParquetValidator(filepath=file_path, table_params={}, metadata=meta)
+    pv = pqv.ParquetValidator(filepath=file_path, table_params={}, metadata=meta)
     pv.read_data_and_validate()
     assert pv.response.result["valid"] == expected_pass


### PR DESCRIPTION
Added new private method (`_read_schema`) to  the `ParquetValidator` to fix an issue with reading a schema from a parquet file in s3. Also added unit tests for the new method.